### PR TITLE
Register HeartRate with dbus.

### DIFF
--- a/datatypes/utils.cpp
+++ b/datatypes/utils.cpp
@@ -39,6 +39,7 @@
 #include "tap.h"
 #include "posedata.h"
 #include "proximity.h"
+#include "heartrate.h"
 
 void __attribute__ ((constructor)) datatypes_init(void)
 {
@@ -55,6 +56,8 @@ void __attribute__ ((constructor)) datatypes_init(void)
     qRegisterMetaType<TimedUnsigned>();
     qRegisterMetaType<PoseData>();
     qRegisterMetaType<Proximity>();
+    qRegisterMetaType<HeartRate>();
+    qDBusRegisterMetaType<HeartRate>();
 }
 
 void __attribute__ ((destructor)) datatypes_fini(void)


### PR DESCRIPTION
This fixes the error message:

Skipped method "HeartRateChanged" : Type not registered with QtDBus in
parameter list: HeartRate
Unsupported return type 1069 HeartRate in method "heartRate"

Signed-off-by: Lorn Potter <lorn.potter@gmail.com>