### PR TITLE
Add support for tilt-to-wake.

### DIFF
--- a/adaptors/adaptors.pro
+++ b/adaptors/adaptors.pro
@@ -12,6 +12,7 @@ contains(CONFIG,hybris) {
     SUBDIRS += hybrisorientationadaptor
     SUBDIRS += hybrisstepcounteradaptor
     SUBDIRS += hybrishrmadaptor
+    SUBDIRS += hybriswristgestureadaptor
 
     } else {
 
@@ -58,6 +59,7 @@ config_hybris {
     SUBDIRS += hybrisorientationadaptor
     SUBDIRS += hybrisstepcounteradaptor
     SUBDIRS += hybrishrmadaptor
+    SUBDIRS += hybriswristgestureadaptor
  }
 }
 

--- a/adaptors/hybriswristgestureadaptor/hybriswristgestureadaptor.cpp
+++ b/adaptors/hybriswristgestureadaptor/hybriswristgestureadaptor.cpp
@@ -1,0 +1,93 @@
+/****************************************************************************
+**
+** Copyright (C) 2013 Jolla Ltd
+** Contact: lorn.potter@jollamobile.com
+**
+** Copyright (C) 2020 Darrel Griët
+** Contact: idanlcontact@gmail.com
+**
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "hybriswristgestureadaptor.h"
+#include "logging.h"
+#include "datatypes/utils.h"
+#include <hardware/sensors.h>
+#include "config.h"
+
+
+#ifndef SENSOR_TYPE_WRIST_TILT_GESTURE
+#define SENSOR_TYPE_WRIST_TILT_GESTURE (26)
+#endif
+
+HybrisWristGestureAdaptor::HybrisWristGestureAdaptor(const QString& id) :
+    HybrisAdaptor(id,SENSOR_TYPE_WRIST_TILT_GESTURE)
+{
+    buffer = new DeviceAdaptorRingBuffer<TimedUnsigned>(1);
+    setAdaptedSensor("hybriswristgesture", "Internal wristgesture coordinates", buffer);
+
+    setDescription("Hybris wristgesture");
+    powerStatePath = Config::configuration()->value("wristgesture/powerstate_path").toByteArray();
+    if (!powerStatePath.isEmpty() && !QFile::exists(powerStatePath))
+    {
+    	sensordLogW() << "Path does not exists: " << powerStatePath;
+    	powerStatePath.clear();
+    }
+}
+
+HybrisWristGestureAdaptor::~HybrisWristGestureAdaptor()
+{
+    delete buffer;
+}
+
+bool HybrisWristGestureAdaptor::startSensor()
+{
+    if(!powerStatePath.isEmpty())
+        writeToFile(powerStatePath, "1");
+    if (!(HybrisAdaptor::startSensor()))
+        return false;
+
+    sensordLogD() << "Hybris WristGestureAdaptor start\n";
+    return true;
+}
+
+void HybrisWristGestureAdaptor::stopSensor()
+{
+    if(!powerStatePath.isEmpty())
+        writeToFile(powerStatePath, "0");
+    HybrisAdaptor::stopSensor();
+    sensordLogD() << "Hybris WristGestureAdaptor stop\n";
+}
+
+void HybrisWristGestureAdaptor::processSample(const sensors_event_t& data)
+{
+    TimedUnsigned *d = buffer->nextSlot();
+    d->timestamp_ = quint64(data.timestamp * .001);
+#ifdef NO_SENSORS_EVENT_U64
+    uint64_t value = 0;
+    memcpy(&value, data.data, sizeof value);
+    d->value_ = value;
+#else
+    d->value_ = data.u64.step_counter;
+#endif
+    sensordLogD() << "HybrisWristGestureAdaptor: processSample(): " << data.data[0];
+
+    buffer->commit();
+    buffer->wakeUpReaders();
+}
+
+void HybrisWristGestureAdaptor::init()
+{
+}

--- a/adaptors/hybriswristgestureadaptor/hybriswristgestureadaptor.h
+++ b/adaptors/hybriswristgestureadaptor/hybriswristgestureadaptor.h
@@ -1,0 +1,62 @@
+/****************************************************************************
+**
+** Copyright (C) 2013 Jolla Ltd
+** Contact: lorn.potter@jollamobile.com
+**
+** Copyright (C) 2020 Darrel Griët
+** Contact: idanlcontact@gmail.com
+**
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef HYBRISWRISTGESTUREADAPTOR_H
+#define HYBRISWRISTGESTUREADAPTOR_H
+#include "hybrisadaptor.h"
+
+#include <QString>
+#include <QStringList>
+#include "deviceadaptorringbuffer.h"
+#include "datatypes/orientationdata.h"
+
+/**
+ * @brief Adaptor for hybris wrist gesture sensor.
+ *
+ * Adaptor for wrist gesture sensor.
+ */
+class HybrisWristGestureAdaptor : public HybrisAdaptor
+{
+    Q_OBJECT
+
+public:
+    static DeviceAdaptor* factoryMethod(const QString& id) {
+        return new HybrisWristGestureAdaptor(id);
+    }
+    HybrisWristGestureAdaptor(const QString& id);
+    ~HybrisWristGestureAdaptor();
+
+    bool startSensor();
+    void stopSensor();
+
+protected:
+    void processSample(const sensors_event_t& data);
+    void init();
+
+private:
+    DeviceAdaptorRingBuffer<TimedUnsigned>* buffer;
+    int sensorType;
+    QByteArray powerStatePath;
+
+};
+#endif

--- a/adaptors/hybriswristgestureadaptor/hybriswristgestureadaptor.pro
+++ b/adaptors/hybriswristgestureadaptor/hybriswristgestureadaptor.pro
@@ -1,0 +1,14 @@
+TARGET       = hybriswristgestureadaptor
+
+HEADERS += hybriswristgestureadaptor.h \
+           hybriswristgestureadaptorplugin.h
+
+SOURCES += hybriswristgestureadaptor.cpp \
+           hybriswristgestureadaptorplugin.cpp
+
+LIBS+= -L../../core -lhybrissensorfw-qt5
+
+include( ../adaptor-config.pri )
+config_hybris {
+    PKGCONFIG += android-headers
+}

--- a/adaptors/hybriswristgestureadaptor/hybriswristgestureadaptorplugin.cpp
+++ b/adaptors/hybriswristgestureadaptor/hybriswristgestureadaptorplugin.cpp
@@ -1,0 +1,38 @@
+/****************************************************************************
+**
+** Copyright (C) 2013 Jolla Ltd
+** Contact: lorn.potter@jollamobile.com
+**
+** Copyright (C) 2020 Darrel Griët
+** Contact: idanlcontact@gmail.com
+**
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "hybriswristgestureadaptorplugin.h"
+#include "hybriswristgestureadaptor.h"
+#include "sensormanager.h"
+#include "logging.h"
+
+void HybrisWristGestureAdaptorPlugin::Register(class Loader&)
+{
+    sensordLogD() << "registering hybriswristgestureadaptor";
+    SensorManager& sm = SensorManager::instance();
+    sm.registerDeviceAdaptor<HybrisWristGestureAdaptor>("wristgestureadaptor");
+}
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+Q_EXPORT_PLUGIN2(hybriswristgestureadaptor, HybrisWristGestureAdaptorPlugin)
+#endif

--- a/adaptors/hybriswristgestureadaptor/hybriswristgestureadaptorplugin.h
+++ b/adaptors/hybriswristgestureadaptor/hybriswristgestureadaptorplugin.h
@@ -1,0 +1,40 @@
+/****************************************************************************
+**
+** Copyright (C) 2013 Jolla Ltd
+** Contact: lorn.potter@jollamobile.com
+**
+** Copyright (C) 2020 Darrel Griët
+** Contact: idanlcontact@gmail.com
+**
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef HYBRISWRISTGESTUREADAPTORPLUGIN_H
+#define HYBRISWRISTGESTUREADAPTORPLUGIN_H
+
+#include "plugin.h"
+
+class HybrisWristGestureAdaptorPlugin : public Plugin
+{
+    Q_OBJECT
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    Q_PLUGIN_METADATA(IID "com.nokia.SensorService.Plugin/1.0")
+#endif
+
+private:
+    void Register(class Loader& l);
+};
+
+#endif

--- a/config/sensord-hybris.conf
+++ b/config/sensord-hybris.conf
@@ -8,6 +8,7 @@ orientationadaptor = hybrisorientationadaptor
 stepcounteradaptor = hybrisstepcounteradaptor
 pressureadaptor = hybrispressureadaptor
 hrmadaptor = hybrishrmadaptor
+wristgestureadaptor = hybriswristgestureadaptor
 
 [magnetometer]
 scale_coefficient = 1

--- a/sensors/sensors.pro
+++ b/sensors/sensors.pro
@@ -17,6 +17,7 @@ SUBDIRS  = accelerometersensor \
            pressuresensor \
            temperaturesensor \
            stepcountersensor \
-           hrmsensor
+           hrmsensor \
+           wristgesturesensor
 
 contextprovider:SUBDIRS += contextplugin

--- a/sensors/wristgesturesensor/wristgestureplugin.cpp
+++ b/sensors/wristgesturesensor/wristgestureplugin.cpp
@@ -1,0 +1,47 @@
+/**
+   @file wristgestureplugin.cpp
+   @brief Plugin for WristGestureSensor
+
+   <p>
+   Copyright (C) 2009-2010 Nokia Corporation
+   Copyright (C) 2020 Darrel Griët
+
+   @author Timo Rongas <ext-timo.2.rongas@nokia.com>
+   @author Ustun Ergenoglu <ext-ustun.ergenoglu@nokia.com>
+   @author Darrel Griët <idanlcontact@gmail.com>
+
+   This file is part of Sensord.
+
+   Sensord is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License
+   version 2.1 as published by the Free Software Foundation.
+
+   Sensord is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Sensord.  If not, see <http://www.gnu.org/licenses/>.
+   </p>
+*/
+
+#include "wristgestureplugin.h"
+#include "wristgesturesensor.h"
+#include "sensormanager.h"
+#include "logging.h"
+
+void WristGesturePlugin::Register(class Loader&)
+{
+    sensordLogD() << "registering wristgesturesensor";
+    SensorManager& sm = SensorManager::instance();
+    sm.registerSensor<WristGestureSensorChannel>("wristgesturesensor");
+}
+
+QStringList WristGesturePlugin::Dependencies() {
+    return QString("wristgestureadaptor").split(":", QString::SkipEmptyParts);
+}
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+Q_EXPORT_PLUGIN2(wristgesturesensor, WristGesturePlugin)
+#endif

--- a/sensors/wristgesturesensor/wristgestureplugin.h
+++ b/sensors/wristgesturesensor/wristgestureplugin.h
@@ -1,0 +1,44 @@
+/**
+   @file orientationplugin.h
+   @brief Plugin for WristGestureSensor
+
+   <p>
+   Copyright (C) 2009-2010 Nokia Corporation
+   Copyright (C) 2020 Darrel Griët
+
+   @author Timo Rongas <ext-timo.2.rongas@nokia.com>
+   @author Darrel Griët <idanlcontact@gmail.com>
+
+   This file is part of Sensord.
+
+   Sensord is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License
+   version 2.1 as published by the Free Software Foundation.
+
+   Sensord is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Sensord.  If not, see <http://www.gnu.org/licenses/>.
+   </p>
+*/
+
+#ifndef WRISTGESTUREPLUGIN_H
+#define WRISTGESTUREPLUGIN_H
+
+#include "plugin.h"
+
+class WristGesturePlugin : public Plugin
+{
+    Q_OBJECT
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    Q_PLUGIN_METADATA(IID "com.nokia.SensorService.Plugin/1.0")
+#endif
+private:
+    void Register(class Loader& l);
+    QStringList Dependencies();
+};
+
+#endif

--- a/sensors/wristgesturesensor/wristgesturesensor.cpp
+++ b/sensors/wristgesturesensor/wristgesturesensor.cpp
@@ -1,0 +1,121 @@
+/**
+   @file wristgesturesensor.cpp
+   @brief WristGestureSensor
+
+   <p>
+   Copyright (C) 2009-2010 Nokia Corporation
+   Copyright (C) 2020 Darrel Griët
+
+   @author Timo Rongas <ext-timo.2.rongas@nokia.com>
+   @author Ustun Ergenoglu <ext-ustun.ergenoglu@nokia.com>
+   @author Darrel Griët <idanlcontact@gmail.com>
+
+   This file is part of Sensord.
+
+   Sensord is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License
+   version 2.1 as published by the Free Software Foundation.
+
+   Sensord is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Sensord.  If not, see <http://www.gnu.org/licenses/>.
+   </p>
+*/
+
+#include "wristgesturesensor.h"
+
+#include "sensormanager.h"
+#include "bin.h"
+#include "bufferreader.h"
+
+WristGestureSensorChannel::WristGestureSensorChannel(const QString& id) :
+        AbstractSensorChannel(id),
+        DataEmitter<TimedUnsigned>(1),
+        prevWristGesture(0,0)
+{
+    SensorManager& sm = SensorManager::instance();
+
+    wristGestureAdaptor_ = sm.requestDeviceAdaptor("wristgestureadaptor");
+    if (!wristGestureAdaptor_) {
+        setValid(false);
+        return;
+    }
+
+    wristgestureReader_ = new BufferReader<TimedUnsigned>(1);
+
+    outputBuffer_ = new RingBuffer<TimedUnsigned>(1);
+
+    // Create buffers for filter chain
+    filterBin_ = new Bin;
+
+    filterBin_->add(wristgestureReader_, "wristgesture");
+    filterBin_->add(outputBuffer_, "buffer");
+
+    // Join filterchain buffers
+    filterBin_->join("wristgesture", "source", "buffer", "sink");
+
+    // Join datasources to the chain
+    connectToSource(wristGestureAdaptor_, "wristgesture", wristgestureReader_);
+
+    marshallingBin_ = new Bin;
+    marshallingBin_->add(this, "sensorchannel");
+
+    outputBuffer_->join(this);
+
+    setDescription("wristgesture sensor for wake up detection");
+    setRangeSource(wristGestureAdaptor_);
+    addStandbyOverrideSource(wristGestureAdaptor_);
+    setIntervalSource(wristGestureAdaptor_);
+
+    setValid(true);
+}
+
+WristGestureSensorChannel::~WristGestureSensorChannel()
+{
+    if (isValid()) {
+        SensorManager& sm = SensorManager::instance();
+
+        disconnectFromSource(wristGestureAdaptor_, "wristgesture", wristgestureReader_);
+
+        sm.releaseDeviceAdaptor("wristgestureadaptor");
+
+        delete wristgestureReader_;
+        delete outputBuffer_;
+        delete marshallingBin_;
+        delete filterBin_;
+    }
+}
+
+bool WristGestureSensorChannel::start()
+{
+    sensordLogD() << "Starting WristGestureSensorChannel";
+
+    if (AbstractSensorChannel::start()) {
+        marshallingBin_->start();
+        filterBin_->start();
+        wristGestureAdaptor_->startSensor();
+    }
+    return true;
+}
+
+bool WristGestureSensorChannel::stop()
+{
+    sensordLogD() << "Stopping WristGestureSensorChannel";
+
+    if (AbstractSensorChannel::stop()) {
+        wristGestureAdaptor_->stopSensor();
+        filterBin_->stop();
+        marshallingBin_->stop();
+    }
+    return true;
+}
+
+void WristGestureSensorChannel::emitData(const TimedUnsigned& value)
+{
+    prevWristGesture.value_ = value.value_;
+    writeToClients((const void *)&value, sizeof(value));
+}

--- a/sensors/wristgesturesensor/wristgesturesensor.h
+++ b/sensors/wristgesturesensor/wristgesturesensor.h
@@ -1,0 +1,114 @@
+/**
+   @file wristgesturesensor.h
+   @brief WristGestureSensor
+
+   <p>
+   Copyright (C) 2009-2010 Nokia Corporation
+   Copyright (C) 2020 Darrel Griët
+
+   @author Timo Rongas <ext-timo.2.rongas@nokia.com>
+   @author Darrel Griët <idanlcontact@gmail.com>
+
+   This file is part of Sensord.
+
+   Sensord is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License
+   version 2.1 as published by the Free Software Foundation.
+
+   Sensord is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Sensord.  If not, see <http://www.gnu.org/licenses/>.
+   </p>
+*/
+
+#ifndef WRISTGESTURE_SENSOR_CHANNEL_H
+#define WRISTGESTURE_SENSOR_CHANNEL_H
+
+#include <QObject>
+
+#include "deviceadaptor.h"
+#include "abstractsensor.h"
+#include "wristgesturesensor_a.h"
+#include "dataemitter.h"
+#include "datatypes/timedunsigned.h"
+#include "datatypes/unsigned.h"
+
+class Bin;
+template <class TYPE> class BufferReader;
+class FilterBase;
+
+/**
+ * @brief Sensor for accessing device wristgesture.
+ *
+ * Provides device wristgesture based on the direction of acceleration vector.
+ * Threshold value (mG) is used to control the sensitivity of change from one
+ * wristgesture into another. See #WristGestureInterpreter for details on threshold.
+ */
+class WristGestureSensorChannel :
+        public AbstractSensorChannel,
+        public DataEmitter<TimedUnsigned>
+{
+    Q_OBJECT;
+    Q_PROPERTY(Unsigned wristgesture READ wristgesture);
+
+public:
+
+    /**
+     * Factory method for WristGestureSensorChannel.
+     * @return New WristGestureSensorChannel as AbstractSensorChannel*
+     */
+    static AbstractSensorChannel* factoryMethod(const QString& id)
+    {
+        WristGestureSensorChannel* sc = new WristGestureSensorChannel(id);
+        new WristGestureSensorChannelAdaptor(sc);
+
+        return sc;
+    }
+
+    /**
+    * Property method returning current wristgesture.
+    * @return Current wristgesture.
+    */
+    Unsigned wristgesture() const
+    {
+        return prevWristGesture;
+    }
+
+public Q_SLOTS:
+    bool start();
+    bool stop();
+
+signals:
+    /**
+     * Sent whenever wristgesture interpretation has changed.
+     * @param wristgesture New wristgesture.
+     */
+    void wristgestureChanged(const int& wristgesture);
+
+protected:
+    WristGestureSensorChannel(const QString& id);
+    virtual ~WristGestureSensorChannel();
+
+private:
+    TimedUnsigned                         prevWristGesture;
+    Bin*                             filterBin_;
+    Bin*                             marshallingBin_;
+
+    DeviceAdaptor*                   wristGestureAdaptor_;
+
+    BufferReader<TimedUnsigned>*   wristgestureReader_;
+
+    RingBuffer<TimedUnsigned>*            outputBuffer_;
+
+    /**
+     * Emits new device wristgesture through DBus.
+     * @param value WristGesture value to emit.
+     */
+    void emitData(const TimedUnsigned& value);
+};
+
+#endif // WRISTGESTURE_SENSOR_CHANNEL_H

--- a/sensors/wristgesturesensor/wristgesturesensor.pro
+++ b/sensors/wristgesturesensor/wristgesturesensor.pro
@@ -1,0 +1,11 @@
+TARGET       = wristgesturesensor
+
+HEADERS += wristgesturesensor.h   \
+           wristgesturesensor_a.h \
+           wristgestureplugin.h
+
+SOURCES += wristgesturesensor.cpp   \
+           wristgesturesensor_a.cpp \
+           wristgestureplugin.cpp
+
+include( ../sensor-config.pri )

--- a/sensors/wristgesturesensor/wristgesturesensor_a.cpp
+++ b/sensors/wristgesturesensor/wristgesturesensor_a.cpp
@@ -1,0 +1,49 @@
+/**
+   @file wristgesturesensor_a.cpp
+   @brief D-Bus Adaptor for WristGestureSensor
+
+   <p>
+   Copyright (C) 2009-2010 Nokia Corporation
+   Copyright (C) 2020 Darrel Griët
+
+   @author Timo Rongas <ext-timo.2.rongas@nokia.com>
+   @author Antti Virtanen <antti.i.virtanen@nokia.com>
+   @author Darrel Griët <idanlcontact@gmail.com>
+
+   This file is part of Sensord.
+
+   Sensord is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License
+   version 2.1 as published by the Free Software Foundation.
+
+   Sensord is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Sensord.  If not, see <http://www.gnu.org/licenses/>.
+   </p>
+*/
+
+#include "wristgesturesensor_a.h"
+
+WristGestureSensorChannelAdaptor::WristGestureSensorChannelAdaptor(QObject* parent) :
+    AbstractSensorChannelAdaptor(parent)
+{
+}
+
+Unsigned WristGestureSensorChannelAdaptor::wristgesture() const
+{
+    return qvariant_cast<Unsigned>(parent()->property("wristgesture"));
+}
+
+int WristGestureSensorChannelAdaptor::threshold() const
+{
+    return qvariant_cast<int>(parent()->property("threshold"));
+}
+
+void WristGestureSensorChannelAdaptor::setThreshold(int value)
+{
+    parent()->setProperty("threshold", value);
+}

--- a/sensors/wristgesturesensor/wristgesturesensor_a.h
+++ b/sensors/wristgesturesensor/wristgesturesensor_a.h
@@ -1,0 +1,57 @@
+/**
+   @file wristgesturesensor_a.h
+   @brief D-Bus Adaptor for WristGestureSensor
+
+   <p>
+   Copyright (C) 2009-2010 Nokia Corporation
+   Copyright (C) 2020 Darrel Griët
+
+   @author Timo Rongas <ext-timo.2.rongas@nokia.com>
+   @author Antti Virtanen <antti.i.virtanen@nokia.com>
+   @author Darrel Griët <idanlcontact@gmail.com>
+
+   This file is part of Sensord.
+
+   Sensord is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License
+   version 2.1 as published by the Free Software Foundation.
+
+   Sensord is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Sensord.  If not, see <http://www.gnu.org/licenses/>.
+   </p>
+*/
+
+#ifndef WRISTGESTURE_SENSOR_H
+#define WRISTGESTURE_SENSOR_H
+
+#include <QtDBus/QtDBus>
+
+#include "datatypes/unsigned.h"
+#include "abstractsensor_a.h"
+
+class WristGestureSensorChannelAdaptor : public AbstractSensorChannelAdaptor
+{
+    Q_OBJECT
+    Q_DISABLE_COPY(WristGestureSensorChannelAdaptor)
+    Q_CLASSINFO("D-Bus Interface", "local.WristGestureSensor")
+    Q_PROPERTY(Unsigned wristgesture READ wristgesture)
+    Q_PROPERTY(int threshold READ threshold WRITE setThreshold)
+
+public:
+    WristGestureSensorChannelAdaptor(QObject* parent);
+
+public Q_SLOTS:
+    Unsigned wristgesture() const;
+    int threshold() const;
+    void setThreshold(int value);
+
+Q_SIGNALS:
+    void wristgestureChanged(const Unsigned& wristgesture);
+};
+
+#endif


### PR DESCRIPTION
This PR adds support for tilt-to-wake!
I have been testing this patch for some days now. And it seems to work fine.

There is also a patch needed for MCE. I can make a PR for this to meta-asteroid. But MCE already has some more patches. So I think it might be better to add the MCE repository to the AsteroidOS organization.
The patchwork for MCE is located here: https://github.com/MagneFire/mce
This work is a continued work of @lpotter (Thanks!).

As usual, this work is only tested for sturgeon, but any smartwatch with the gesture sensor(sensor type 26 in test_sensors) should work.

This PR and a patch/new repo for MCE should fix https://github.com/AsteroidOS/asteroid/issues/97