### PR TITLE
Enable stepcounter

### DIFF
--- a/config/20-sensors-default.conf
+++ b/config/20-sensors-default.conf
@@ -32,7 +32,6 @@ temperaturesensor=False
 ; Sensors that have not been available in any officially supported
 ; devices -> hide by default.
 humiditysensor=False
-stepcountersensor=False
 
 ; To minimize chances of regression, sensors that have been available at
 ; least in one officially supported device -> do not hide by default.
@@ -42,6 +41,9 @@ stepcountersensor=False
 magnetometersensor=True
 pressuresensor=True
 rotationsensor=True
+stepcountersensor=True
+hrmsensor=True
+wristgesturesensor=True
 
 ; To avoid revisiting config files for all old ports in the future, the
 ; defaults for added sensors should be set "False" by default here, and


### PR DESCRIPTION
And also set the delay for the stepcounter sensor. This fixes the stepcounter on at least sturgeon.
I am not sure if setting the delay for the stepcounter is a general enough solution, maybe it's better suited as a separate patch for the sturgeon repo? (hrm and tilt-to-wake have the same patch applied in this repo)

Here is how I tested the sensor:
```
dbus-send --system --print-reply --type=method_call --dest=com.nokia.SensorService /SensorManager local.SensorManager.loadPlugin string:"stepcountersensor"
dbus-send --system --print-reply --type=method_call --dest=com.nokia.SensorService /SensorManager/stepcountersensor local.StepCounterSensor.start int32:42
```
Execute these commands as root. Additionally you may want to enable verbose logging in `sensorfw` to check if you receive `HYBRIS EVE STEP_COUNTER` events.